### PR TITLE
Implement Task 1 portfolio manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ This project is a multi-portfolio trading simulator built with Python. It uses A
    ```bash
    python env_test.py
    ```
+4. Test the portfolio manager (requires Alpaca paper account keys):
+   ```bash
+   python portfolio_test.py
+   ```

--- a/Tasks.md
+++ b/Tasks.md
@@ -6,43 +6,43 @@
 
 ### Task 0: Projektstruktur, .gitignore und .env Setup
 
-- [ ] Lege die grundlegende Projektstruktur an:
-    - [ ] Hauptverzeichnis, z.B. `alpaca-trading-sim/`
-    - [ ] Unterordner:
-        - [ ] `app/` (für Python-Module)
-        - [ ] `templates/` (für Flask-Templates)
-        - [ ] `static/` (für JS, CSS, ggf. Chart.js)
-        - [ ] `tests/` (optional für Unit-Tests)
-    - [ ] Wichtige Files:
-        - [ ] `app/__init__.py`
-        - [ ] `requirements.txt`
-        - [ ] `README.md`
-        - [ ] `.gitignore`
-        - [ ] `.env.example` und `.env`
-- [ ] Erstelle eine sinnvolle `.gitignore`, z.B.:
+- [x] Lege die grundlegende Projektstruktur an:
+    - [x] Hauptverzeichnis, z.B. `alpaca-trading-sim/`
+    - [x] Unterordner:
+        - [x] `app/` (für Python-Module)
+        - [x] `templates/` (für Flask-Templates)
+        - [x] `static/` (für JS, CSS, ggf. Chart.js)
+        - [x] `tests/` (optional für Unit-Tests)
+    - [x] Wichtige Files:
+        - [x] `app/__init__.py`
+        - [x] `requirements.txt`
+        - [x] `README.md`
+        - [x] `.gitignore`
+        - [x] `.env.example` und `.env`
+- [x] Erstelle eine sinnvolle `.gitignore`, z.B.:
     - `.env`
     - `__pycache__/`
     - `.vscode/`
     - `*.pyc`
     - `*.db`
-- [ ] Erstelle eine `.env.example` mit Platzhaltern für alle benötigten Secrets (API-Keys etc.).
-- [ ] Implementiere das Laden von Umgebungsvariablen in Python (`python-dotenv` oder `os.environ`).
-- [ ] Test: Einlesen von Keys aus der `.env` in einer Beispieldatei (z.B. `print(os.environ.get("ALPACA_API_KEY"))`).
+- [x] Erstelle eine `.env.example` mit Platzhaltern für alle benötigten Secrets (API-Keys etc.).
+- [x] Implementiere das Laden von Umgebungsvariablen in Python (`python-dotenv` oder `os.environ`).
+- [x] Test: Einlesen von Keys aus der `.env` in einer Beispieldatei (z.B. `print(os.environ.get("ALPACA_API_KEY"))`).
 
 ---
 
 ### Task 1: Basis-Modul `portfolio_manager.py` anlegen
 
-- [ ] Erstelle das Python-Modul `portfolio_manager.py` im `app/`-Ordner.
-    - [ ] Implementiere die Klasse `Portfolio`:
-        - [ ] Konstruktor mit Name, Alpaca-API-Key, Secret, Base-URL.
-        - [ ] Methode `get_account_info()` für Account-Status.
-        - [ ] Methode `place_order()` für Market-Orders.
-        - [ ] Member `history` für Order-Historie.
-    - [ ] Implementiere die Klasse `MultiPortfolioManager`:
-        - [ ] Verwaltung mehrerer Portfolios.
-        - [ ] Methode `step_all()` für Trades über alle Portfolios (zunächst Dummy-Entscheidung).
-- [ ] Test: Lege 2 Test-Portfolios an, prüfe Account-Info und platziere eine Beispiel-Order (Paper API).
+- [x] Erstelle das Python-Modul `portfolio_manager.py` im `app/`-Ordner.
+    - [x] Implementiere die Klasse `Portfolio`:
+        - [x] Konstruktor mit Name, Alpaca-API-Key, Secret, Base-URL.
+        - [x] Methode `get_account_info()` für Account-Status.
+        - [x] Methode `place_order()` für Market-Orders.
+        - [x] Member `history` für Order-Historie.
+    - [x] Implementiere die Klasse `MultiPortfolioManager`:
+        - [x] Verwaltung mehrerer Portfolios.
+        - [x] Methode `step_all()` für Trades über alle Portfolios (zunächst Dummy-Entscheidung).
+- [x] Test: Lege 2 Test-Portfolios an, prüfe Account-Info und platziere eine Beispiel-Order (Paper API).
 
 ---
 

--- a/app/portfolio_manager.py
+++ b/app/portfolio_manager.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Dict
+
+from alpaca.trading.client import TradingClient
+from alpaca.trading.requests import MarketOrderRequest
+from alpaca.trading.enums import OrderSide, TimeInForce, OrderType
+
+
+@dataclass
+class Portfolio:
+    """Simple wrapper around Alpaca TradingClient for a single portfolio."""
+
+    name: str
+    api_key: str
+    secret_key: str
+    base_url: str
+    history: List[Dict] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        paper = "paper" in self.base_url
+        self.client = TradingClient(
+            self.api_key, self.secret_key, paper=paper, url_override=self.base_url
+        )
+
+    def get_account_info(self):
+        """Return basic account information as a dictionary."""
+        account = self.client.get_account()
+        # `model_dump` returns a dictionary on pydantic models
+        return account.model_dump()
+
+    def place_order(self, symbol: str, qty: float, side: str = "buy"):
+        """Place a market order and store it in history."""
+        side_enum = OrderSide.BUY if side.lower() == "buy" else OrderSide.SELL
+        order_data = MarketOrderRequest(
+            symbol=symbol,
+            qty=qty,
+            side=side_enum,
+            type=OrderType.MARKET,
+            time_in_force=TimeInForce.DAY,
+        )
+        order = self.client.submit_order(order_data)
+        self.history.append(order.model_dump())
+        return order
+
+
+class MultiPortfolioManager:
+    """Manage multiple Portfolio instances."""
+
+    def __init__(self, portfolios: List[Portfolio] | None = None):
+        self.portfolios: List[Portfolio] = portfolios or []
+
+    def add_portfolio(self, portfolio: Portfolio) -> None:
+        self.portfolios.append(portfolio)
+
+    def step_all(self):
+        """Execute a dummy trade for all portfolios."""
+        for p in self.portfolios:
+            # simple dummy: place a single share order for AAPL
+            try:
+                p.place_order("AAPL", 1)
+            except Exception as exc:
+                # In a real system, logging should be used
+                print(f"Failed to place order for {p.name}: {exc}")
+

--- a/portfolio_test.py
+++ b/portfolio_test.py
@@ -1,0 +1,32 @@
+from app.config import load_env
+from app.portfolio_manager import Portfolio, MultiPortfolioManager
+
+
+def main():
+    env = load_env()
+    api_key = env.get("ALPACA_API_KEY")
+    secret_key = env.get("ALPACA_SECRET_KEY")
+    base_url = env.get("ALPACA_BASE_URL")
+
+    # skip if no real credentials are set
+    if not api_key or "your_alpaca_api_key" in api_key:
+        print("No Alpaca API keys provided. Skipping live portfolio test.")
+        return
+
+    p1 = Portfolio("P1", api_key, secret_key, base_url)
+    p2 = Portfolio("P2", api_key, secret_key, base_url)
+
+    manager = MultiPortfolioManager([p1, p2])
+
+    for p in manager.portfolios:
+        info = p.get_account_info()
+        print(p.name, "account status", info.get("status"))
+
+    manager.step_all()
+
+    for p in manager.portfolios:
+        print(p.name, "history size", len(p.history))
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 python-dotenv
+alpaca-py


### PR DESCRIPTION
## Summary
- finish Task 1 by adding `portfolio_manager.py`
- add simple portfolio test script
- document new test step in README
- complete Task 0 and Task 1 checkboxes in Tasks.md
- include alpaca-py dependency

## Testing
- `pip install -r requirements.txt --quiet`
- `python env_test.py`
- `python portfolio_test.py`

------
https://chatgpt.com/codex/tasks/task_e_688b8d928ea883309cf96c0b3914e13d