### PR TITLE
Implement research engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ This project is a multi-portfolio trading simulator built with Python. It uses A
    ```bash
    python portfolio_test.py
    ```
+5. Run the research engine test (requires network and API keys for best results):
+   ```bash
+   python research_test.py
+   ```

--- a/app/research_engine.py
+++ b/app/research_engine.py
@@ -1,0 +1,72 @@
+import os
+import requests
+from textblob import TextBlob
+
+from .config import load_env
+
+
+ENV = load_env()
+FINNHUB_API_KEY = ENV.get("FINNHUB_API_KEY")
+NEWS_API_KEY = ENV.get("NEWS_API_KEY")
+
+
+def get_fundamentals_yahoo(symbol: str) -> dict:
+    """Fetch basic fundamentals from Yahoo Finance."""
+    url = f"https://query1.finance.yahoo.com/v7/finance/quote?symbols={symbol}"
+    try:
+        resp = requests.get(url, headers={"User-Agent": "Mozilla/5.0"}, timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+def get_news_finnhub(symbol: str) -> list:
+    """Fetch recent news for a symbol from Finnhub or NewsAPI."""
+    if FINNHUB_API_KEY:
+        url = (
+            f"https://finnhub.io/api/v1/company-news?symbol={symbol}&from=2020-01-01&to=2020-12-31&token={FINNHUB_API_KEY}"
+        )
+        try:
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception:
+            pass
+    if NEWS_API_KEY:
+        url = (
+            f"https://newsapi.org/v2/everything?q={symbol}&apiKey={NEWS_API_KEY}"
+        )
+        try:
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("articles", [])
+        except Exception:
+            pass
+    return []
+
+
+def analyze_sentiment(news_items: list) -> float:
+    """Very basic sentiment score based on news headlines."""
+    if not news_items:
+        return 0.0
+    scores = []
+    for item in news_items:
+        text = item.get("headline") or item.get("title") or ""
+        blob = TextBlob(text)
+        scores.append(blob.sentiment.polarity)
+    return sum(scores) / len(scores) if scores else 0.0
+
+
+def get_research(symbol: str) -> dict:
+    """Return combined research data for a symbol."""
+    fundamentals = get_fundamentals_yahoo(symbol)
+    news = get_news_finnhub(symbol)
+    sentiment = analyze_sentiment(news)
+    return {
+        "symbol": symbol,
+        "fundamentals": fundamentals,
+        "news": news,
+        "sentiment": sentiment,
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 python-dotenv
 alpaca-py
+requests
+textblob

--- a/research_test.py
+++ b/research_test.py
@@ -1,0 +1,5 @@
+from app.research_engine import get_research
+
+if __name__ == "__main__":
+    data = get_research("AAPL")
+    print(data)


### PR DESCRIPTION
## Summary
- add research_engine module with Yahoo, Finnhub and NewsAPI helpers
- update requirements with requests and textblob
- document research test in README
- add research_test script

## Testing
- `pip install -r requirements.txt --quiet`
- `python env_test.py`
- `python portfolio_test.py`
- `python research_test.py`

------
https://chatgpt.com/codex/tasks/task_e_688b8fad0f2c83309b1c24c042901edb