### PR TITLE
Implement task 3 from Tasks.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ This project is a multi-portfolio trading simulator built with Python. It uses A
    ```bash
    python research_test.py
    ```
+6. Try the OpenAI strategy demo:
+   ```bash
+   python strategy_test.py
+   ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-dotenv
 alpaca-py
 requests
 textblob
+openai

--- a/strategy_test.py
+++ b/strategy_test.py
@@ -1,0 +1,26 @@
+from app.config import load_env
+from app.portfolio_manager import Portfolio, get_strategy_from_openai
+from app.research_engine import get_research
+
+
+def main():
+    env = load_env()
+    api_key = env.get("ALPACA_API_KEY")
+    secret_key = env.get("ALPACA_SECRET_KEY")
+    base_url = env.get("ALPACA_BASE_URL")
+
+    # skip if no real credentials are set
+    if not api_key or "your_alpaca_api_key" in api_key:
+        print("No Alpaca API keys provided. Skipping strategy test.")
+        return
+
+    p = Portfolio("Test", api_key, secret_key, base_url)
+    research = get_research("AAPL")
+    strat1 = get_strategy_from_openai(p, research, "momentum")
+    strat2 = get_strategy_from_openai(p, research, "mean_reversion")
+    print("momentum:", strat1)
+    print("mean_reversion:", strat2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- integrate OpenAI in portfolio manager
- fetch research and ask OpenAI for trading decisions
- add simple strategy test script
- document OpenAI strategy demo in README
- add openai dependency

## Testing
- `pip install -r requirements.txt`
- `python env_test.py`
- `python portfolio_test.py`
- `python research_test.py | head`
- `python strategy_test.py`

------
https://chatgpt.com/codex/tasks/task_e_688b90b5d31c8330af2f7649076fa6c7