### PR TITLE
Implement task 7 with per-portfolio strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ This project is a multi-portfolio trading simulator built with Python. It uses A
    ```bash
    python app.py
    ```
+   The dashboard lets you pick a strategy for each portfolio from a dropdown.

--- a/Tasks.md
+++ b/Tasks.md
@@ -100,11 +100,11 @@
 
 ### Task 7: Strategie pro Portfolio steuerbar machen
 
-- [ ] Erweitere `Portfolio` um ein Attribut `strategy_type`.
-- [ ] Im Dashboard: Dropdown für Strategieauswahl je Portfolio.
-    - [ ] Neue Route `/portfolio/<name>/set_strategy` im Backend.
-    - [ ] Nach Änderung wird beim nächsten Schritt die neue Strategie genutzt.
-- [ ] Test: Verschiedene Strategien führen zu unterschiedlichem Trading-Verhalten.
+- [x] Erweitere `Portfolio` um ein Attribut `strategy_type`.
+- [x] Im Dashboard: Dropdown für Strategieauswahl je Portfolio.
+    - [x] Neue Route `/portfolio/<name>/set_strategy` im Backend.
+    - [x] Nach Änderung wird beim nächsten Schritt die neue Strategie genutzt.
+- [x] Test: Verschiedene Strategien führen zu unterschiedlichem Trading-Verhalten.
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, redirect, url_for
+from flask import Flask, render_template, redirect, url_for, request
 from flask_socketio import SocketIO
 
 from app.config import load_env
@@ -36,6 +36,7 @@ def _portfolio_snapshot():
             "portfolio_value": value,
             "history": p.history[-5:],
             "equity": p.equity_curve[-50:],
+            "strategy_type": p.strategy_type,
         })
     return data
 
@@ -51,6 +52,16 @@ def step():
     manager.step_all()
     portfolios = _portfolio_snapshot()
     socketio.emit("trade_update", portfolios, broadcast=True)
+    return redirect(url_for("index"))
+
+
+@app.route("/portfolio/<name>/set_strategy", methods=["POST"])
+def set_strategy(name: str):
+    strategy = request.form.get("strategy_type", "default")
+    for p in manager.portfolios:
+        if p.name == name:
+            p.strategy_type = strategy
+            break
     return redirect(url_for("index"))
 
 

--- a/app/portfolio_manager.py
+++ b/app/portfolio_manager.py
@@ -26,6 +26,7 @@ class Portfolio:
     api_key: str
     secret_key: str
     base_url: str
+    strategy_type: str = "default"
     history: List[Dict] = field(default_factory=list)
     equity_curve: List[Dict] = field(default_factory=list)
 
@@ -94,11 +95,11 @@ class MultiPortfolioManager:
     def add_portfolio(self, portfolio: Portfolio) -> None:
         self.portfolios.append(portfolio)
 
-    def step_all(self, symbol: str = "AAPL", strategy_type: str = "default"):
+    def step_all(self, symbol: str = "AAPL"):
         """Get research and ask OpenAI for a trade decision for each portfolio."""
         for p in self.portfolios:
             research = get_research(symbol)
-            decision = get_strategy_from_openai(p, research, strategy_type)
+            decision = get_strategy_from_openai(p, research, p.strategy_type)
             print(p.name, "decision", decision)
             if decision.lower().startswith("buy"):
                 try:

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,6 +38,8 @@
             data.forEach(p => {
                 const el = document.getElementById('portfolio-' + p.name);
                 if (!el) return;
+                const select = el.querySelector('select[name="strategy_type"]');
+                if (select) select.value = p.strategy_type;
                 el.querySelector('.cash').textContent = p.cash;
                 el.querySelector('.portfolio_value').textContent = p.portfolio_value;
                 const historyList = el.querySelector('.history');

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -9,6 +9,15 @@
     {% for p in portfolios %}
     <div id="portfolio-{{ p.name }}" class="bg-white shadow p-4 rounded">
         <h2 class="text-xl font-semibold">{{ p.name }}</h2>
+        <form method="post" action="{{ url_for('set_strategy', name=p.name) }}" class="my-2">
+            <label class="text-sm">Strategy:
+                <select name="strategy_type" onchange="this.form.submit()" class="border rounded px-1 py-0">
+                    {% for s in ['default', 'momentum', 'mean_reversion'] %}
+                    <option value="{{ s }}" {% if p.strategy_type == s %}selected{% endif %}>{{ s }}</option>
+                    {% endfor %}
+                </select>
+            </label>
+        </form>
         <p>Cash: <span class="cash">{{ p.cash }}</span></p>
         <p>Portfolio value: <span class="portfolio_value">{{ p.portfolio_value }}</span></p>
         <div class="h-48">

--- a/tests/strategy_test.py
+++ b/tests/strategy_test.py
@@ -1,6 +1,5 @@
 from app.config import load_env
-from app.portfolio_manager import Portfolio, get_strategy_from_openai
-from app.research_engine import get_research
+from app.portfolio_manager import Portfolio, MultiPortfolioManager
 
 
 def main():
@@ -14,12 +13,12 @@ def main():
         print("No Alpaca API keys provided. Skipping strategy test.")
         return
 
-    p = Portfolio("Test", api_key, secret_key, base_url)
-    research = get_research("AAPL")
-    strat1 = get_strategy_from_openai(p, research, "momentum")
-    strat2 = get_strategy_from_openai(p, research, "mean_reversion")
-    print("momentum:", strat1)
-    print("mean_reversion:", strat2)
+    p1 = Portfolio("Momentum", api_key, secret_key, base_url, "momentum")
+    p2 = Portfolio("MeanRev", api_key, secret_key, base_url, "mean_reversion")
+    manager = MultiPortfolioManager([p1, p2])
+    manager.step_all("AAPL")
+    for p in manager.portfolios:
+        print(p.name, p.strategy_type, "trades", len(p.history))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow selecting a strategy per portfolio
- add strategy dropdown to dashboard template and keep selection updated via SocketIO
- expose new `/portfolio/<name>/set_strategy` route
- extend `Portfolio` dataclass with `strategy_type`
- adjust `MultiPortfolioManager.step_all` to use the portfolio's strategy
- update tasks checklist and README note
- adapt strategy test

## Testing
- `pip install -q -r requirements.txt`
- `python -m tests.env_test`
- `python -m tests.portfolio_test`
- `python -m tests.research_test`
- `python -m tests.strategy_test`


------
https://chatgpt.com/codex/tasks/task_e_688bb41cf20883308550ec0299f4d215