### PR TITLE
Implement task 11 risk management

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,12 @@ This project is a multi-portfolio trading simulator built with Python. It uses A
    ```bash
    python -m tests.strategy_test
    ```
+7. Run the risk management test:
+   ```bash
+   python -m tests.risk_test
+   ```
 
-7. Run the Flask dashboard:
+8. Run the Flask dashboard:
    ```bash
    python app.py
    ```

--- a/Tasks.md
+++ b/Tasks.md
@@ -135,12 +135,12 @@
 
 ### Task 11: Intelligentes Positions- und Risikomanagement
 
-- [ ] Implementiere Risiko-Features pro Portfolio:
-    - [ ] Setze Stop-Loss, Take-Profit, Max-Drawdown-Limits (einstellbar pro Portfolio).
-    - [ ] Bei Überschreiten automatisches Schließen von Positionen oder Warnmeldungen.
-    - [ ] Ergänze einen “Smart Allocator” für Positionsgrößen anhand Risikoniveau und/oder KI-Empfehlung.
-    - [ ] Visualisiere Risikostatus und Alarme im Dashboard.
-    - [ ] Test: Simuliere einen Drawdown und prüfe, ob korrekt reagiert wird.
+- [x] Implementiere Risiko-Features pro Portfolio:
+    - [x] Setze Stop-Loss, Take-Profit, Max-Drawdown-Limits (einstellbar pro Portfolio).
+    - [x] Bei Überschreiten automatisches Schließen von Positionen oder Warnmeldungen.
+    - [x] Ergänze einen “Smart Allocator” für Positionsgrößen anhand Risikoniveau und/oder KI-Empfehlung.
+    - [x] Visualisiere Risikostatus und Alarme im Dashboard.
+    - [x] Test: Simuliere einen Drawdown und prüfe, ob korrekt reagiert wird.
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -50,6 +50,10 @@ def _portfolio_snapshot():
             "equity_norm": manager.get_normalized_equity(p)[-50:],
             "benchmark": bench[-50:],
             "strategy_type": p.strategy_type,
+            "risk_alerts": p.risk_alerts[-5:],
+            "stop_loss_pct": p.stop_loss_pct,
+            "take_profit_pct": p.take_profit_pct,
+            "max_drawdown_pct": p.max_drawdown_pct,
         })
     return data
 

--- a/app/benchmark.py
+++ b/app/benchmark.py
@@ -30,6 +30,11 @@ def get_latest_benchmark_price(symbol: str = "^spx") -> Dict[str, str | float]:
     return {}
 
 
+def get_latest_price(symbol: str) -> Dict[str, str | float]:
+    """Return latest close price for any symbol from Stooq."""
+    return get_latest_benchmark_price(symbol)
+
+
 def normalize_curve(curve: List[Dict[str, float]]) -> List[Dict[str, float]]:
     """Normalize time series values to start at 100."""
     if not curve:

--- a/templates/base.html
+++ b/templates/base.html
@@ -60,6 +60,20 @@
                     });
                 }
 
+                const alertList = el.querySelector('.risk_alerts');
+                if (alertList) {
+                    alertList.innerHTML = '';
+                    if (p.risk_alerts.length === 0) {
+                        alertList.innerHTML = '<li>No alerts.</li>';
+                    } else {
+                        p.risk_alerts.forEach(a => {
+                            const item = document.createElement('li');
+                            item.textContent = a;
+                            alertList.appendChild(item);
+                        });
+                    }
+                }
+
                 const labels = p.equity_norm.map(e => e.time);
                 const values = p.equity_norm.map(e => e.value);
                 const benchValues = p.benchmark.map(b => b.value);

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -37,6 +37,14 @@
         <div class="h-48">
             <canvas id="chart-{{ p.name }}"></canvas>
         </div>
+        <h3 class="font-semibold mt-2">Risk Alerts</h3>
+        <ul class="list-disc list-inside risk_alerts">
+            {% for alert in p.risk_alerts %}
+            <li>{{ alert }}</li>
+            {% else %}
+            <li>No alerts.</li>
+            {% endfor %}
+        </ul>
         <h3 class="font-semibold mt-2">Trades</h3>
         <ul class="list-disc list-inside history">
             {% for trade in p.history %}

--- a/tests/risk_test.py
+++ b/tests/risk_test.py
@@ -1,0 +1,15 @@
+from app.portfolio_manager import Portfolio
+
+
+def main():
+    # create portfolio with dummy keys
+    p = Portfolio("Risk", "key", "secret", "https://paper-api.alpaca.markets")
+    p.max_drawdown_pct = 0.1
+    p.initial_value = 100.0
+    p.high_water = 100.0
+    p.check_risk(85.0, simulate=True)
+    print("alerts", p.risk_alerts)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add generic price fetch helper
- implement portfolio risk management with stop loss, take profit and drawdown
- use smart allocation in trade loop
- surface risk alerts on the dashboard
- mark task 11 complete
- document risk test

## Testing
- `pip install -r requirements.txt`
- `python -m tests.env_test`
- `python -m tests.risk_test`
- `python -m tests.portfolio_test`
- `python -m tests.research_test`
- `python -m tests.strategy_test`
- `python -m tests.benchmark_test`


------
https://chatgpt.com/codex/tasks/task_e_688bbee077f48330bab3447eca0de0da