### PR TITLE
Implement custom prompt editor

### DIFF
--- a/Tasks.md
+++ b/Tasks.md
@@ -167,11 +167,11 @@
 
 ### Task 14: Strategie-Editor mit Custom Prompts (No-Code-Editor für OpenAI-Trading-Strategien)
 
-- [ ] Entwickle einen Editor im Dashboard, mit dem User eigene OpenAI-Prompts/Strategie-Templates konfigurieren können (ohne Programmierung).
-    - [ ] Speichere die Prompts pro Portfolio in der Datenbank oder als JSON.
-    - [ ] Validierung der Eingaben, Vorschau auf das Resultat.
-    - [ ] Binde die Custom-Prompts in die Entscheidungslogik ein, sodass bei jedem Trade der gewählte Prompt genutzt wird.
-    - [ ] Test: Definiere einen eigenen Prompt und führe Trades danach aus.
+- [x] Entwickle einen Editor im Dashboard, mit dem User eigene OpenAI-Prompts/Strategie-Templates konfigurieren können (ohne Programmierung).
+    - [x] Speichere die Prompts pro Portfolio in der Datenbank oder als JSON.
+    - [x] Validierung der Eingaben, Vorschau auf das Resultat.
+    - [x] Binde die Custom-Prompts in die Entscheidungslogik ein, sodass bei jedem Trade der gewählte Prompt genutzt wird.
+    - [x] Test: Definiere einen eigenen Prompt und führe Trades danach aus.
 
 ---
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,6 +13,26 @@
         const socket = io();
         const charts = {};
 
+        async function previewPrompt(name) {
+            const form = document.querySelector(`#portfolio-${name} form[action$='set_prompt']`);
+            if (!form) return;
+            const textarea = form.querySelector('textarea[name="custom_prompt"]');
+            const previewEl = document.getElementById('preview-' + name);
+            if (!textarea || !previewEl) return;
+            const data = new FormData();
+            data.append('custom_prompt', textarea.value);
+            try {
+                const resp = await fetch(`/portfolio/${name}/preview_prompt`, {
+                    method: 'POST',
+                    body: data
+                });
+                const text = await resp.text();
+                previewEl.textContent = text;
+            } catch (err) {
+                previewEl.textContent = 'error';
+            }
+        }
+
         function createChart(name, labels, values, benchValues) {
             const ctx = document.getElementById('chart-' + name).getContext('2d');
             charts[name] = new Chart(ctx, {
@@ -46,6 +66,8 @@
                 if (!el) return;
                 const select = el.querySelector('select[name="strategy_type"]');
                 if (select) select.value = p.strategy_type;
+                const promptArea = el.querySelector('textarea[name="custom_prompt"]');
+                if (promptArea) promptArea.value = p.custom_prompt || '';
                 el.querySelector('.cash').textContent = p.cash;
                 el.querySelector('.portfolio_value').textContent = p.portfolio_value;
                 const divScoreEl = el.querySelector('.divscore');

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -27,10 +27,19 @@
             <label class="text-sm">Strategy:
                 <select name="strategy_type" onchange="this.form.submit()" class="border rounded px-1 py-0">
                     {% for s in ['default', 'momentum', 'mean_reversion'] %}
-                    <option value="{{ s }}" {% if p.strategy_type == s %}selected{% endif %}>{{ s }}</option>
+                        <option value="{{ s }}" {% if p.strategy_type == s %}selected{% endif %}>{{ s }}</option>
                     {% endfor %}
                 </select>
             </label>
+        </form>
+        <form method="post" action="{{ url_for('set_prompt', name=p.name) }}" class="my-2">
+            <label class="text-sm font-semibold">Custom Prompt:</label>
+            <textarea name="custom_prompt" rows="3" class="border rounded w-full">{{ p.custom_prompt }}</textarea>
+            <div class="flex items-center space-x-2 mt-1">
+                <button type="submit" class="bg-purple-500 hover:bg-purple-700 text-white text-xs px-2 py-1 rounded">Save</button>
+                <button type="button" onclick="previewPrompt('{{ p.name }}')" class="bg-gray-300 text-xs px-2 py-1 rounded">Preview</button>
+                <span id="preview-{{ p.name }}" class="text-xs"></span>
+            </div>
         </form>
         <p>Cash: <span class="cash">{{ p.cash }}</span></p>
         <p>Portfolio value: <span class="portfolio_value">{{ p.portfolio_value }}</span></p>

--- a/tests/custom_prompt_test.py
+++ b/tests/custom_prompt_test.py
@@ -1,0 +1,24 @@
+from app.config import load_env
+from app.portfolio_manager import Portfolio, MultiPortfolioManager, get_strategy_from_openai
+from app.research_engine import get_research
+
+
+def main():
+    env = load_env()
+    api_key = env.get("ALPACA_API_KEY")
+    secret_key = env.get("ALPACA_SECRET_KEY")
+    base_url = env.get("ALPACA_BASE_URL")
+
+    if not api_key or "your_alpaca_api_key" in api_key:
+        print("No Alpaca API keys provided. Skipping custom prompt test.")
+        return
+
+    portfolio = Portfolio("Custom", api_key, secret_key, base_url, "default", "Buy {research[symbol]} if sentiment > 0")
+    manager = MultiPortfolioManager([portfolio])
+    research = get_research("AAPL")
+    decision = get_strategy_from_openai(portfolio, research, portfolio.strategy_type)
+    print("Decision:", decision)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add new `custom_prompt` field for `Portfolio`
- load/save custom prompts to `portfolios.json`
- hook custom prompts into OpenAI strategy logic
- add routes to set and preview prompts
- extend dashboard with text area editor and preview
- adjust dashboard JS to sync prompts
- document completion of Task 14
- add test for custom prompt usage

## Testing
- `python -m tests.env_test`
- `python -m tests.portfolio_test`
- `python -m tests.research_test`
- `python -m tests.strategy_test`
- `python -m tests.risk_test`
- `python -m tests.diversification_test`
- `python -m tests.report_test`
- `python -m tests.benchmark_test`
- `python -m tests.custom_prompt_test`


------
https://chatgpt.com/codex/tasks/task_e_688bc70a29188330a89b46ce92e854e4