### PR TITLE
Implement live positions overview

### DIFF
--- a/Tasks.md
+++ b/Tasks.md
@@ -185,10 +185,10 @@ Alle Tasks sind so formuliert, dass sie einzeln umgesetzt werden können. Vieles
 ```markdown
 ### Task 15: Live-Positionsübersicht pro Portfolio (Bot)
 
-- [ ] Baue eine Live-Ansicht aller offenen Positionen je Portfolio ins Dashboard:
-    - [ ] Symbol, Stückzahl, aktueller Kurs, durchschnittlicher Einstiegskurs, aktueller Gewinn/Verlust (absolut/relativ)
-    - [ ] Echtzeit-Update via SocketIO/Websocket
-    - [ ] Sortier- und Filteroption (z.B. nach Gewinn/Verlust)
+- [x] Baue eine Live-Ansicht aller offenen Positionen je Portfolio ins Dashboard:
+    - [x] Symbol, Stückzahl, aktueller Kurs, durchschnittlicher Einstiegskurs, aktueller Gewinn/Verlust (absolut/relativ)
+    - [x] Echtzeit-Update via SocketIO/Websocket
+    - [x] Sortier- und Filteroption (z.B. nach Gewinn/Verlust)
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -62,23 +62,26 @@ def _portfolio_snapshot():
         p.correlation_matrix = divers["matrix"]
         p.diversification_score = divers["score"]
         p.diversification_warnings = divers["warnings"]
-        data.append({
-            "name": p.name,
-            "cash": cash,
-            "portfolio_value": value,
-            "history": p.history[-5:],
-            "equity": p.equity_curve[-50:],
-            "equity_norm": manager.get_normalized_equity(p)[-50:],
-            "benchmark": bench[-50:],
-            "strategy_type": p.strategy_type,
-            "custom_prompt": p.custom_prompt,
-            "risk_alerts": p.risk_alerts[-5:] + p.diversification_warnings,
-            "stop_loss_pct": p.stop_loss_pct,
-            "take_profit_pct": p.take_profit_pct,
-            "max_drawdown_pct": p.max_drawdown_pct,
-            "diversification_score": p.diversification_score,
-            "correlation": p.correlation_matrix,
-        })
+        data.append(
+            {
+                "name": p.name,
+                "cash": cash,
+                "portfolio_value": value,
+                "positions": p.get_positions(),
+                "history": p.history[-5:],
+                "equity": p.equity_curve[-50:],
+                "equity_norm": manager.get_normalized_equity(p)[-50:],
+                "benchmark": bench[-50:],
+                "strategy_type": p.strategy_type,
+                "custom_prompt": p.custom_prompt,
+                "risk_alerts": p.risk_alerts[-5:] + p.diversification_warnings,
+                "stop_loss_pct": p.stop_loss_pct,
+                "take_profit_pct": p.take_profit_pct,
+                "max_drawdown_pct": p.max_drawdown_pct,
+                "diversification_score": p.diversification_score,
+                "correlation": p.correlation_matrix,
+            }
+        )
     return data
 
 
@@ -139,7 +142,9 @@ def preview_prompt(name: str):
         return "Unknown portfolio", 404
     original_prompt = temp_portfolio.custom_prompt
     temp_portfolio.custom_prompt = prompt
-    decision = get_strategy_from_openai(temp_portfolio, research, temp_portfolio.strategy_type)
+    decision = get_strategy_from_openai(
+        temp_portfolio, research, temp_portfolio.strategy_type
+    )
     temp_portfolio.custom_prompt = original_prompt
     return decision
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,6 +12,7 @@
     <script>
         const socket = io();
         const charts = {};
+        const positionsStore = {};
 
         async function previewPrompt(name) {
             const form = document.querySelector(`#portfolio-${name} form[action$='set_prompt']`);
@@ -57,6 +58,52 @@
                     maintainAspectRatio: false
                 }
             });
+        }
+
+        function renderPositions(name) {
+            const data = positionsStore[name] || [];
+            const table = document.getElementById('positions-' + name);
+            if (!table) return;
+            const sortSelect = document.getElementById('pos-sort-' + name);
+            const filterInput = document.getElementById('pos-filter-' + name);
+            let items = data.slice();
+            if (filterInput && filterInput.value) {
+                const term = filterInput.value.toLowerCase();
+                items = items.filter(pos => pos.symbol.toLowerCase().includes(term));
+            }
+            const sortKey = sortSelect ? sortSelect.value : 'symbol';
+            items.sort((a, b) => {
+                if (sortKey === 'pnl') return b.pnl - a.pnl;
+                return a.symbol.localeCompare(b.symbol);
+            });
+            const tbody = table.querySelector('tbody');
+            tbody.innerHTML = '';
+            if (items.length === 0) {
+                const row = document.createElement('tr');
+                const td = document.createElement('td');
+                td.colSpan = 5;
+                td.textContent = 'No positions';
+                row.appendChild(td);
+                tbody.appendChild(row);
+            } else {
+                items.forEach(pos => {
+                    const row = document.createElement('tr');
+                    row.innerHTML =
+                        `<td class="border px-1">${pos.symbol}</td>` +
+                        `<td class="border px-1">${pos.qty}</td>` +
+                        `<td class="border px-1">${pos.price.toFixed(2)}</td>` +
+                        `<td class="border px-1">${pos.avg_price.toFixed(2)}</td>` +
+                        `<td class="border px-1">${pos.pnl.toFixed(2)} (${(pos.pnl_pct*100).toFixed(2)}%)</td>`;
+                    tbody.appendChild(row);
+                });
+            }
+        }
+
+        function attachPositionHandlers(name) {
+            const sortSelect = document.getElementById('pos-sort-' + name);
+            const filterInput = document.getElementById('pos-filter-' + name);
+            if (sortSelect) sortSelect.addEventListener('change', () => renderPositions(name));
+            if (filterInput) filterInput.addEventListener('input', () => renderPositions(name));
         }
 
         function updatePortfolios(data) {
@@ -130,6 +177,10 @@
                     charts[p.name].data.datasets[1].data = benchValues;
                     charts[p.name].update();
                 }
+
+                positionsStore[p.name] = p.positions || [];
+                attachPositionHandlers(p.name);
+                renderPositions(p.name);
             });
         }
 
@@ -140,6 +191,7 @@
             if (dataElement) {
                 const portfolios = JSON.parse(dataElement.textContent);
                 updatePortfolios(portfolios);
+                portfolios.forEach(p => attachPositionHandlers(p.name));
             }
         });
     </script>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -69,6 +69,28 @@
             <li>No alerts.</li>
             {% endfor %}
         </ul>
+        <div class="mt-2">
+            <h3 class="font-semibold">Positions</h3>
+            <div class="flex space-x-2 mb-1 text-sm">
+                <input type="text" placeholder="Filter" id="pos-filter-{{ p.name }}" class="border px-1 py-0">
+                <select id="pos-sort-{{ p.name }}" class="border px-1 py-0">
+                    <option value="symbol">Symbol</option>
+                    <option value="pnl">PnL</option>
+                </select>
+            </div>
+            <table class="text-xs border w-full" id="positions-{{ p.name }}">
+                <thead>
+                    <tr>
+                        <th class="border px-1">Symbol</th>
+                        <th class="border px-1">Qty</th>
+                        <th class="border px-1">Price</th>
+                        <th class="border px-1">Avg</th>
+                        <th class="border px-1">PnL</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </div>
         <div class="flex items-center justify-between mt-2">
             <h3 class="font-semibold">Trades</h3>
             <div class="space-x-2 text-sm">


### PR DESCRIPTION
## Summary
- implement positions tracking in `Portfolio` via `get_positions`
- expose positions in `_portfolio_snapshot`
- display live positions table per portfolio with filtering and sorting
- update JS to render positions in realtime
- mark Task 15 complete in Tasks.md

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c663aae3c8330bcde7886e1415d32