### PR TITLE
Implement allocation feature

### DIFF
--- a/Tasks.md
+++ b/Tasks.md
@@ -225,13 +225,13 @@
 
 ### Task 19: Investitionsübersicht & Asset-Allokation
 
-- [ ] **Backend**:  
-    - [ ] Berechne und aggregiere die aktuelle Verteilung aller Investments je Portfolio.
-    - [ ] API-Route `/api/portfolio/<name>/allocation`  
+- [x] **Backend**:
+    - [x] Berechne und aggregiere die aktuelle Verteilung aller Investments je Portfolio.
+    - [x] API-Route `/api/portfolio/<name>/allocation`
       Liefert Allokation als Liste/Prozentwerte je Asset.
-- [ ] **Frontend**:  
-    - [ ] Pie Chart (Chart.js) für Investment Breakdown im Dashboard.
-    - [ ] Klumpenrisiken visuell hervorheben.
+- [x] **Frontend**:
+    - [x] Pie Chart (Chart.js) für Investment Breakdown im Dashboard.
+    - [x] Klumpenrisiken visuell hervorheben.
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -73,6 +73,7 @@ def _portfolio_snapshot():
                 "positions": p.get_positions(),
                 "history": p.history[-5:],
                 "open_orders": p.open_orders,
+                "allocation": p.get_allocation(),
                 "equity": p.equity_curve[-50:],
                 "equity_norm": manager.get_normalized_equity(p)[-50:],
                 "benchmark": bench[-50:],
@@ -161,6 +162,15 @@ def api_orders(name: str):
         if p.name == name:
             return {"orders": p.get_orders(status=status)}
     return {"orders": []}
+
+
+@app.route("/api/portfolio/<name>/allocation")
+def api_allocation(name: str):
+    """Return current asset allocation for a portfolio."""
+    for p in manager.portfolios:
+        if p.name == name:
+            return {"allocation": p.get_allocation()}
+    return {"allocation": []}
 
 
 @app.route("/api/portfolio/<name>/trade_history")

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,9 +14,11 @@
         const charts = {};
         const tradeCharts = {};
         const tradePriceCharts = {};
+        const allocationCharts = {};
         const positionsStore = {};
         const ordersStore = {};
         const tradeStore = {};
+        const allocStore = {};
 
         async function previewPrompt(name) {
             const form = document.querySelector(`#portfolio-${name} form[action$='set_prompt']`);
@@ -62,6 +64,29 @@
                     maintainAspectRatio: false
                 }
             });
+        }
+
+        function renderAllocation(name) {
+            const data = allocStore[name] || [];
+            const ctxEl = document.getElementById('alloc-chart-' + name);
+            if (!ctxEl) return;
+            const ctx = ctxEl.getContext('2d');
+            const labels = data.map(a => a.symbol);
+            const values = data.map(a => a.percent);
+            const colors = values.map(v => v > 50 ? 'rgb(255, 99, 132)' : 'rgb(54, 162, 235)');
+            if (!allocationCharts[name]) {
+                allocationCharts[name] = new Chart(ctx, {
+                    type: 'pie',
+                    data: { labels: labels, datasets: [{ data: values, backgroundColor: colors }] },
+                    options: { responsive: true, maintainAspectRatio: false }
+                });
+            } else {
+                const chart = allocationCharts[name];
+                chart.data.labels = labels;
+                chart.data.datasets[0].data = values;
+                chart.data.datasets[0].backgroundColor = colors;
+                chart.update();
+            }
         }
 
         function renderPositions(name) {
@@ -325,9 +350,11 @@
 
                 positionsStore[p.name] = p.positions || [];
                 ordersStore[p.name] = p.open_orders || [];
+                allocStore[p.name] = p.allocation || [];
                 attachPositionHandlers(p.name);
                 renderPositions(p.name);
                 renderOrders(p.name);
+                renderAllocation(p.name);
             });
         }
 
@@ -341,6 +368,7 @@
                 portfolios.forEach(p => {
                     attachPositionHandlers(p.name);
                     loadTradeHistory(p.name);
+                    renderAllocation(p.name);
                 });
             }
         });

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -61,6 +61,9 @@
                 </tbody>
             </table>
         </div>
+        <div class="h-32 mt-2">
+            <canvas id="alloc-chart-{{ p.name }}"></canvas>
+        </div>
         <h3 class="font-semibold mt-2">Risk Alerts</h3>
         <ul class="list-disc list-inside risk_alerts">
             {% for alert in p.risk_alerts %}


### PR DESCRIPTION
## Summary
- calculate portfolio allocation with percentage breakdown
- expose `/api/portfolio/<name>/allocation` endpoint
- show asset allocation pie chart in dashboard
- mark allocation task complete

## Testing
- `python env_test.py`
- `python research_test.py`
- `python price_history_test.py`
- `python risk_test.py`
- `python diversification_test.py`
- `python benchmark_test.py`
- `python report_test.py`
- `python trade_history_test.py`
- `python strategy_test.py`
- `python portfolio_test.py`


------
https://chatgpt.com/codex/tasks/task_e_688c792078688330af15bdbca1ca065a