### PR TITLE
Implement alerts and threshold management

### DIFF
--- a/Tasks.md
+++ b/Tasks.md
@@ -276,14 +276,14 @@
 
 ### Task 23: Alerts und Schwellenwert-Warnungen
 
-- [ ] **Backend**:  
-    - [ ] Felder für Schwellenwerte im Portfolio/Trade (max. Drawdown, PnL-Limits).
-    - [ ] Überwache in der Trade- und Positionslogik, ob Schwellenwerte überschritten werden.
-    - [ ] API-Route `/api/portfolio/<name>/alerts`
-    - [ ] Push Alerts per SocketIO und ggf. E-Mail/Push.
-- [ ] **Frontend**:  
-    - [ ] Anzeigen und Konfigurieren von Alerts im Dashboard.
-    - [ ] Visual/Akustisch (z.B. Banner, Sound).
+- [x] **Backend**:
+    - [x] Felder für Schwellenwerte im Portfolio/Trade (max. Drawdown, PnL-Limits).
+    - [x] Überwache in der Trade- und Positionslogik, ob Schwellenwerte überschritten werden.
+    - [x] API-Route `/api/portfolio/<name>/alerts`
+    - [x] Push Alerts per SocketIO und ggf. E-Mail/Push.
+- [x] **Frontend**:
+    - [x] Anzeigen und Konfigurieren von Alerts im Dashboard.
+    - [x] Visual/Akustisch (z.B. Banner, Sound).
 
 ---
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -406,6 +406,14 @@
                 if (select) select.value = p.strategy_type;
                 const promptArea = el.querySelector('textarea[name="custom_prompt"]');
                 if (promptArea) promptArea.value = p.custom_prompt || '';
+                const sl = el.querySelector('input[name="stop_loss_pct"]');
+                if (sl) sl.value = p.stop_loss_pct;
+                const tp = el.querySelector('input[name="take_profit_pct"]');
+                if (tp) tp.value = p.take_profit_pct;
+                const dd = el.querySelector('input[name="max_drawdown_pct"]');
+                if (dd) dd.value = p.max_drawdown_pct;
+                const pnlLim = el.querySelector('input[name="trade_pnl_limit_pct"]');
+                if (pnlLim) pnlLim.value = p.trade_pnl_limit_pct;
                 el.querySelector('.cash').textContent = p.cash;
                 el.querySelector('.portfolio_value').textContent = p.portfolio_value;
                 const divScoreEl = el.querySelector('.divscore');
@@ -481,6 +489,9 @@
             list.push(data.event);
             activityStore[data.name] = list.slice(-100);
             renderActivity(data.name);
+            if (data.event.type === 'alert') {
+                alert(`${data.name}: ${data.event.message}`);
+            }
         });
         // initial bootstrap from server rendered data
         document.addEventListener('DOMContentLoaded', () => {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -41,6 +41,21 @@
                 <span id="preview-{{ p.name }}" class="text-xs"></span>
             </div>
         </form>
+        <form method="post" action="{{ url_for('set_alerts', name=p.name) }}" class="my-2 text-xs space-x-2">
+            <label>SL%
+                <input type="number" step="0.01" name="stop_loss_pct" value="{{ p.stop_loss_pct }}" class="border w-16 px-1 py-0">
+            </label>
+            <label>TP%
+                <input type="number" step="0.01" name="take_profit_pct" value="{{ p.take_profit_pct }}" class="border w-16 px-1 py-0">
+            </label>
+            <label>DD%
+                <input type="number" step="0.01" name="max_drawdown_pct" value="{{ p.max_drawdown_pct }}" class="border w-16 px-1 py-0">
+            </label>
+            <label>Trade%
+                <input type="number" step="0.01" name="trade_pnl_limit_pct" value="{{ p.trade_pnl_limit_pct }}" class="border w-16 px-1 py-0">
+            </label>
+            <button type="submit" class="bg-yellow-500 hover:bg-yellow-700 text-white px-2 py-1 rounded">Save</button>
+        </form>
         <p>Cash: <span class="cash">{{ p.cash }}</span></p>
         <p>Portfolio value: <span class="portfolio_value">{{ p.portfolio_value }}</span></p>
         <div class="h-48">


### PR DESCRIPTION
## Summary
- add `trade_pnl_limit_pct` threshold in `Portfolio`
- check trade pnl and generate alerts when limit is exceeded
- provide route to update alert thresholds
- expose alerts via new API endpoint
- push alert messages via SocketIO and show them in UI
- add alert configuration form in dashboard
- mark Task 23 as complete

## Testing
- `python env_test.py`
- `python risk_test.py`
- `python portfolio_test.py`
- `python custom_prompt_test.py`
- `python research_test.py`
- `python trade_history_test.py`
- `python price_history_test.py`
- `python benchmark_test.py`
- `python diversification_test.py`
- `python report_test.py`
- `python strategy_test.py`

------
https://chatgpt.com/codex/tasks/task_e_688c8949b6d48330874a03f98eec4811