### PR TITLE
Implement task 26 export feature

### DIFF
--- a/Tasks.md
+++ b/Tasks.md
@@ -311,11 +311,11 @@
 
 ### Task 26: Export aller Dashboard-Daten
 
-- [ ] **Backend**:  
-    - [ ] Export-Logik für CSV, JSON, PDF aller Portfolio-/Trade-/Chart-Daten.
-    - [ ] API-Route `/api/portfolio/<name>/export?format=csv|json|pdf`
-- [ ] **Frontend**:  
-    - [ ] Export-Button im Dashboard, Auswahl von Bereich und Format.
+- [x] **Backend**:
+    - [x] Export-Logik für CSV, JSON, PDF aller Portfolio-/Trade-/Chart-Daten.
+    - [x] API-Route `/api/portfolio/<name>/export?format=csv|json|pdf`
+- [x] **Frontend**:
+    - [x] Export-Button im Dashboard, Auswahl von Bereich und Format.
 
 ---
 

--- a/app/reporting.py
+++ b/app/reporting.py
@@ -1,9 +1,13 @@
 import csv
+import json
 from datetime import datetime
 from pathlib import Path
-from typing import List
+from typing import List, Dict, Any
 
-from .portfolio_manager import Portfolio
+from fpdf import FPDF
+
+from .portfolio_manager import Portfolio, MultiPortfolioManager
+from .diversification import analyze_portfolio
 
 
 def export_trades_csv(portfolios: List[Portfolio], output_dir: str | Path = "reports") -> List[Path]:
@@ -57,3 +61,74 @@ def generate_reports(portfolios: List[Portfolio], output_dir: str | Path = "repo
             writer.writerow([p.name, f"{stats['profit']:.2f}", f"{stats['winrate']:.2f}"])
         paths.append(file_path)
     return paths
+
+
+def dashboard_snapshot(portfolio: Portfolio, manager: MultiPortfolioManager) -> Dict[str, Any]:
+    """Return a data dictionary similar to the dashboard view."""
+    manager.update_benchmark()
+    bench = manager.get_normalized_benchmark()
+    info = portfolio.get_account_info()
+    portfolio.refresh_open_orders()
+    divers = analyze_portfolio(portfolio)
+    portfolio.correlation_matrix = divers["matrix"]
+    portfolio.diversification_score = divers["score"]
+    portfolio.diversification_warnings = divers["warnings"]
+    return {
+        "name": portfolio.name,
+        "cash": info.get("cash"),
+        "portfolio_value": info.get("portfolio_value"),
+        "positions": portfolio.get_positions(),
+        "history": portfolio.history,
+        "open_orders": portfolio.open_orders,
+        "allocation": portfolio.get_allocation(),
+        "equity": portfolio.equity_curve,
+        "equity_norm": manager.get_normalized_equity(portfolio),
+        "benchmark": bench,
+        "strategy_type": portfolio.strategy_type,
+        "custom_prompt": portfolio.custom_prompt,
+        "risk_alerts": portfolio.risk_alerts,
+        "stop_loss_pct": portfolio.stop_loss_pct,
+        "take_profit_pct": portfolio.take_profit_pct,
+        "max_drawdown_pct": portfolio.max_drawdown_pct,
+        "trade_pnl_limit_pct": portfolio.trade_pnl_limit_pct,
+        "diversification_score": portfolio.diversification_score,
+        "correlation": portfolio.correlation_matrix,
+    }
+
+
+def export_dashboard_data(
+    portfolio: Portfolio,
+    manager: MultiPortfolioManager,
+    fmt: str = "json",
+    output_dir: str | Path = "reports",
+) -> Path | Dict[str, Any]:
+    """Export dashboard data in the given format and return path or dict."""
+    data = dashboard_snapshot(portfolio, manager)
+    if fmt == "json":
+        return data
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if fmt == "csv":
+        file_path = output_dir / f"{portfolio.name}_dashboard.csv"
+        with file_path.open("w", newline="") as f:
+            writer = csv.writer(f)
+            for key, val in data.items():
+                writer.writerow([key, json.dumps(val, default=str)])
+        return file_path
+    if fmt == "pdf":
+        file_path = output_dir / f"{portfolio.name}_dashboard.pdf"
+        pdf = FPDF()
+        pdf.add_page()
+        pdf.set_font("Arial", size=12)
+        pdf.cell(0, 10, f"Dashboard Export: {portfolio.name}", ln=True)
+        for key, val in data.items():
+            pdf.set_font("Arial", "B", 12)
+            pdf.cell(0, 10, key, ln=True)
+            pdf.set_font("Arial", size=10)
+            txt = json.dumps(val, default=str)[:1000]
+            for line in txt.splitlines():
+                pdf.multi_cell(0, 5, line)
+        pdf.output(str(file_path))
+        return file_path
+    raise ValueError("unknown format")

--- a/dashboard_export_test.py
+++ b/dashboard_export_test.py
@@ -1,0 +1,21 @@
+import importlib.util
+from app.portfolio_manager import Portfolio
+
+spec = importlib.util.spec_from_file_location("flask_app", "app.py")
+flask_app = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(flask_app)
+manager = flask_app.manager
+
+
+def main():
+    p = Portfolio("ExportTest", "key", "secret", "https://paper-api.alpaca.markets")
+    p.history = [{"id": "1", "symbol": "AAPL", "side": "buy", "qty": 1}]
+    manager.portfolios = [p]
+    client = flask_app.app.test_client()
+    resp = client.get("/api/portfolio/ExportTest/export?format=json")
+    print("status", resp.status_code)
+    if resp.is_json:
+        print("name", resp.json.get("name"))
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ openai
 Flask
 Flask-SocketIO
 pandas
+fpdf2

--- a/templates/base.html
+++ b/templates/base.html
@@ -45,6 +45,12 @@
             }
         }
 
+        function exportDashboard(name) {
+            const sel = document.getElementById('export-format-' + name);
+            const fmt = sel ? sel.value : 'json';
+            window.location = `/api/portfolio/${name}/export?format=${fmt}`;
+        }
+
         function createChart(name, labels, values, benchValues) {
             const ctx = document.getElementById('chart-' + name).getContext('2d');
             charts[name] = new Chart(ctx, {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -162,6 +162,12 @@
             <div class="space-x-2 text-sm">
                 <a href="{{ url_for('export_trades', name=p.name) }}" class="text-blue-500">Download</a>
                 <a href="{{ url_for('get_report', name=p.name) }}" class="text-blue-500">Report</a>
+                <select id="export-format-{{ p.name }}" class="border text-xs">
+                    <option value="json">json</option>
+                    <option value="csv">csv</option>
+                    <option value="pdf">pdf</option>
+                </select>
+                <a href="#" onclick="exportDashboard('{{ p.name }}')" class="text-blue-500">Export</a>
             </div>
         </div>
         <div class="h-24 mt-1">


### PR DESCRIPTION
## Summary
- implement dashboard export logic in `reporting.py`
- add `/api/portfolio/<name>/export` API route
- provide export button and handler in dashboard UI
- add test for the export route
- update requirements with `fpdf2`
- mark Task 26 as completed

## Testing
- `python benchmark_test.py`
- `python custom_prompt_test.py`
- `python diversification_test.py`
- `python env_test.py`
- `python notes_tags_test.py`
- `python portfolio_test.py`
- `python price_history_test.py`
- `python report_test.py`
- `python research_test.py`
- `python risk_test.py`
- `python strategy_test.py`
- `python trade_history_test.py`
- `python dashboard_export_test.py`

------
https://chatgpt.com/codex/tasks/task_e_688c8fb9f390833080601f96f3d3d416