### PR TITLE
Fix UUID serialization in OpenAI prompt

### DIFF
--- a/app/portfolio_manager.py
+++ b/app/portfolio_manager.py
@@ -388,8 +388,8 @@ def get_strategy_from_openai(
         try:
             prompt = portfolio.custom_prompt.format(
                 strategy_type=strategy_type,
-                portfolio=json.dumps(account),
-                research=json.dumps(research),
+                portfolio=json.dumps(account, default=str),
+                research=json.dumps(research, default=str),
             )
         except Exception as exc:
             logger.error(
@@ -400,8 +400,8 @@ def get_strategy_from_openai(
         prompt = (
             "Provide a short trading decision (buy/sell/hold) for the next step.\n"
             f"Strategy: {strategy_type}\n"
-            f"Portfolio: {json.dumps(account)}\n"
-            f"Research: {json.dumps(research)}"
+            f"Portfolio: {json.dumps(account, default=str)}\n"
+            f"Research: {json.dumps(research, default=str)}"
         )
     portfolio.last_prompt = prompt
     portfolio.last_research = research


### PR DESCRIPTION
## Summary
- ensure account info is JSON serializable when forming prompts

## Testing
- `python -m env_test`
- `python -m portfolio_test`
- `python -m research_test`
- `python -m strategy_test`
- `python -m risk_test`
- `python -m diversification_test`
- `python -m price_history_test`
- `python -m trade_history_test`
- `python -m benchmark_test`
- `python -m dashboard_export_test`
- `python -m custom_prompt_test`
- `python -m multi_portfolio_keys_test`
- `python -m notes_tags_test`
- `python -m report_test`


------
https://chatgpt.com/codex/tasks/task_e_688c977a117c833092a896dfcacdf4df