### PR TITLE
Fix OpenAI error handling

### DIFF
--- a/app/portfolio_manager.py
+++ b/app/portfolio_manager.py
@@ -414,7 +414,7 @@ def get_strategy_from_openai(
         decision = resp["choices"][0]["message"]["content"].strip()
         portfolio.last_response = decision
         return decision
-    except openai.error.RateLimitError:
+    except openai.RateLimitError:
         logger.warning("OpenAI rate limit reached for %s", portfolio.name)
         portfolio.last_response = "rate_limit"
         return "rate_limit"


### PR DESCRIPTION
## Summary
- update reference for OpenAI RateLimitError

## Testing
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_688c9998f9e4833086cc4d00fa38a6a4