### PR TITLE
Add buy-only trading mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ This project is a multi-portfolio trading simulator built with Python. It uses A
    separated list of symbols. If left blank, the simulator will trade a set of
    trending tickers automatically. Set `TRENDING_SOURCE=openai` in your `.env`
    file to let ChatGPT suggest trending symbols instead of using Yahoo Finance.
+   The **Buy Only** button works similarly but ignores sell signals and only
+   executes trades when a buy recommendation is returned.
 
 ## Custom Prompt Editor
 

--- a/app.py
+++ b/app.py
@@ -135,6 +135,20 @@ def step():
     return redirect(url_for("index"))
 
 
+@app.route("/buy", methods=["POST"])
+def buy():
+    """Look for buy opportunities only and place orders."""
+    logger.info("Scanning for buy opportunities")
+    symbols_param = request.form.get("symbols", "").strip()
+    symbols = None
+    if symbols_param:
+        symbols = [s.strip().upper() for s in symbols_param.split(",") if s.strip()]
+    manager.buy_opportunities(symbols)
+    portfolios = _portfolio_snapshot()
+    socketio.emit("trade_update", portfolios)
+    return redirect(url_for("index"))
+
+
 @app.route("/portfolio/<name>/set_strategy", methods=["POST"])
 def set_strategy(name: str):
     strategy = request.form.get("strategy_type", "default")

--- a/docs/Dashboard_Anleitung.md
+++ b/docs/Dashboard_Anleitung.md
@@ -24,6 +24,7 @@ Bestehende Portfolios lassen sich über den "Delete"-Button entfernen.
 ## Simulation ausführen
 
 Über den Button **Step** wird ein Simulationsschritt für alle Portfolios ausgelöst. Die Ergebnisse erscheinen anschließend im Dashboard.
+Der Button **Buy Only** sucht dagegen explizit nach Kaufmöglichkeiten und führt nur Kauforders aus.
 
 ## Strategie auswählen und Prompts anpassen
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -19,6 +19,10 @@
     <input type="text" name="symbols" placeholder="Symbols (comma or auto)" class="border px-1 py-0" />
     <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">Step</button>
 </form>
+<form method="post" action="{{ url_for('buy') }}" class="mb-4 space-x-2">
+    <input type="text" name="symbols" placeholder="Symbols (comma or auto)" class="border px-1 py-0" />
+    <button type="submit" class="bg-green-600 hover:bg-green-800 text-white font-bold py-2 px-4 rounded">Buy Only</button>
+</form>
 <div class="mb-4">
     <a href="{{ url_for('compare_view') }}" class="text-blue-500">Compare Portfolios</a>
 </div>


### PR DESCRIPTION
## Summary
- add `buy_opportunities` helper to only execute buy signals
- expose new `/buy` route in Flask app
- add **Buy Only** form in dashboard template
- document buy-only button in README and manual

## Testing
- `python env_test.py`
- `python risk_test.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_688caafe3e0c8330b382b333041112c7