### PR TITLE
Increase activity log height in dashboard

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -149,7 +149,7 @@
                     </select>
                 </label>
             </div>
-            <ul id="activity-log-{{ p.name }}" class="list-disc list-inside text-xs max-h-32 overflow-y-auto"></ul>
+            <ul id="activity-log-{{ p.name }}" class="list-disc list-inside text-xs max-h-64 overflow-y-auto"></ul>
         </div>
         <div class="mt-2">
             <div class="flex items-center space-x-2 text-xs mb-1">


### PR DESCRIPTION
## Summary
- enlarge activity log to show more entries

## Testing
- `python env_test.py`
- `python benchmark_test.py`
- `python custom_prompt_test.py`
- `python dashboard_export_test.py`
- `python diversification_test.py`
- `python notes_tags_test.py`
- `python price_history_test.py`
- `python report_test.py`
- `python research_test.py`
- `python risk_test.py`
- `python strategy_test.py`
- `python multi_portfolio_keys_test.py`
- `python trade_history_test.py`


------
https://chatgpt.com/codex/tasks/task_e_688cb3a84e1c8330acc58cba2c9e0c71