### PR TITLE
Add manual liquidation controls

### DIFF
--- a/app.py
+++ b/app.py
@@ -234,6 +234,29 @@ def api_orders(name: str):
     return {"orders": []}
 
 
+@app.route("/api/portfolio/<name>/liquidate", methods=["POST"])
+def api_liquidate(name: str):
+    """Liquidate a single position manually."""
+    data = request.get_json(silent=True) or {}
+    symbol = data.get("symbol") or request.form.get("symbol")
+    if not symbol:
+        return {"error": "symbol_required"}, 400
+    for p in manager.portfolios:
+        if p.name == name:
+            qty = p.holdings.get(symbol, 0)
+            if qty <= 0:
+                return {"error": "position_not_found"}, 404
+            try:
+                p.place_order(symbol, qty, "sell")
+            except Exception as exc:
+                logger.error("Manual liquidation failed for %s: %s", p.name, exc)
+                return {"error": str(exc)}, 500
+            portfolios = _portfolio_snapshot()
+            socketio.emit("trade_update", portfolios)
+            return {"status": "ok"}
+    return {"error": "not_found"}, 404
+
+
 @app.route("/api/portfolio/<name>/allocation")
 def api_allocation(name: str):
     """Return current asset allocation for a portfolio."""

--- a/templates/base.html
+++ b/templates/base.html
@@ -78,6 +78,19 @@
             window.location = `/api/portfolio/${name}/export?format=${fmt}`;
         }
 
+        async function liquidatePosition(name, symbol) {
+            if (!confirm(`Liquidate ${symbol}?`)) return;
+            try {
+                await fetch(`/api/portfolio/${name}/liquidate`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ symbol })
+                });
+            } catch (err) {
+                console.error('liquidate failed', err);
+            }
+        }
+
         function createChart(name, labels, values, benchValues) {
             const ctx = document.getElementById('chart-' + name).getContext('2d');
             charts[name] = new Chart(ctx, {
@@ -148,19 +161,32 @@
             if (items.length === 0) {
                 const row = document.createElement('tr');
                 const td = document.createElement('td');
-                td.colSpan = 5;
+                td.colSpan = 6;
                 td.textContent = 'No positions';
                 row.appendChild(td);
                 tbody.appendChild(row);
             } else {
                 items.forEach(pos => {
                     const row = document.createElement('tr');
-                    row.innerHTML =
-                        `<td class="border px-1">${pos.symbol}</td>` +
-                        `<td class="border px-1">${pos.qty}</td>` +
-                        `<td class="border px-1">${pos.price.toFixed(2)}</td>` +
-                        `<td class="border px-1">${pos.avg_price.toFixed(2)}</td>` +
-                        `<td class="border px-1">${pos.pnl.toFixed(2)} (${(pos.pnl_pct*100).toFixed(2)}%)</td>`;
+                    function cell(txt) {
+                        const td = document.createElement('td');
+                        td.className = 'border px-1';
+                        td.textContent = txt;
+                        return td;
+                    }
+                    row.appendChild(cell(pos.symbol));
+                    row.appendChild(cell(pos.qty));
+                    row.appendChild(cell(pos.price.toFixed(2)));
+                    row.appendChild(cell(pos.avg_price.toFixed(2)));
+                    row.appendChild(cell(`${pos.pnl.toFixed(2)} (${(pos.pnl_pct*100).toFixed(2)}%)`));
+                    const actionTd = document.createElement('td');
+                    actionTd.className = 'border px-1';
+                    const btn = document.createElement('button');
+                    btn.textContent = 'Sell';
+                    btn.className = 'text-red-500';
+                    btn.addEventListener('click', () => liquidatePosition(name, pos.symbol));
+                    actionTd.appendChild(btn);
+                    row.appendChild(actionTd);
                     tbody.appendChild(row);
                 });
             }

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -142,6 +142,7 @@
                         <th class="border px-1">Price</th>
                         <th class="border px-1">Avg</th>
                         <th class="border px-1">PnL</th>
+                        <th class="border px-1">Action</th>
                     </tr>
                 </thead>
                 <tbody></tbody>


### PR DESCRIPTION
## Summary
- expose API to liquidate a portfolio position
- add Action column in dashboard positions table
- render liquidate buttons and implement JS handler

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cb7fc66808330bdd4a52d9100e40c