### PR TITLE
Add debug view for OpenAI prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ This project is a multi-portfolio trading simulator built with Python. It uses A
    file to let ChatGPT suggest trending symbols instead of using Yahoo Finance.
    The **Buy Only** button works similarly but ignores sell signals and only
    executes trades when a buy recommendation is returned.
+   Select **debug** in the Activity filter to view the exact prompts sent to
+   OpenAI and the received responses.
 
 ## Custom Prompt Editor
 

--- a/app.py
+++ b/app.py
@@ -277,6 +277,8 @@ def api_activity_log(name: str):
                 events = [e for e in events if e.get("type") == "trade"]
             elif type_filter == "alerts":
                 events = [e for e in events if e.get("type") == "alert"]
+            elif type_filter == "debug":
+                events = [e for e in events if e.get("type") in ("prompt", "response")]
             return {"log": events[-limit:]}
     return {"log": []}
 

--- a/app/portfolio_manager.py
+++ b/app/portfolio_manager.py
@@ -403,6 +403,7 @@ def get_strategy_from_openai(
         )
     portfolio.last_prompt = prompt
     portfolio.last_research = research
+    portfolio.log_event("prompt", prompt)
     try:
         client = openai.OpenAI(api_key=openai.api_key)
         resp = client.chat.completions.create(
@@ -412,14 +413,17 @@ def get_strategy_from_openai(
         )
         decision = resp.choices[0].message.content.strip()
         portfolio.last_response = decision
+        portfolio.log_event("response", decision)
         return decision
     except openai.RateLimitError:
         logger.warning("OpenAI rate limit reached for %s", portfolio.name)
         portfolio.last_response = "rate_limit"
+        portfolio.log_event("response", "rate_limit")
         return "rate_limit"
     except Exception as exc:
         logger.error("OpenAI error for %s: %s", portfolio.name, exc)
         portfolio.last_response = f"error: {exc}"
+        portfolio.log_event("response", f"error: {exc}")
         return f"error: {exc}"
 
 

--- a/docs/Dashboard_Anleitung.md
+++ b/docs/Dashboard_Anleitung.md
@@ -42,6 +42,8 @@ Felder für **Stop Loss**, **Take Profit**, **Max Drawdown** und **Trade PnL Lim
 - **Positions** listen alle offenen Positionen. Sortieren und Filtern ist möglich.
 - **Open Orders** zeigt aktuelle Orders samt Status.
 - **Activity** protokolliert Aktionen wie Trades oder Alerts (Filterbar nach Typ).
+- Über den neuen Filter **debug** lassen sich die an OpenAI gesendeten Prompts
+  und die erhaltenen Antworten einsehen.
 - **PnL Charts** stellen Gewinn/Verlust über verschiedene Intervalle dar.
 - **Trades** listet die abgeschlossenen Trades. Über das Eingabefeld können Notizen und Tags gespeichert werden. Klick auf einen Eintrag öffnet Details und Preisverlauf des Trades; der Button "Warum?" zeigt den Decision-Explainer.
 - Über die Links **Download**, **Report** und **Export** lassen sich Handelsdaten bzw. komplette Dashboard-Daten exportieren (JSON, CSV oder PDF).

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -170,6 +170,7 @@
                         <option value="all">all</option>
                         <option value="trades">trades</option>
                         <option value="alerts">alerts</option>
+                        <option value="debug">debug</option>
                     </select>
                 </label>
             </div>


### PR DESCRIPTION
## Summary
- log prompt and response in `get_strategy_from_openai`
- expose them via new `debug` filter in `api_activity_log`
- add `debug` option in dashboard activity filter
- document the debug filter in README and German dashboard guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cb85036588330a5b8dae8f60d92bb